### PR TITLE
Use GitHub releses instead of docker tags for more accurate versions and updated doc

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -48,7 +48,7 @@ jobs:
       group: build-and-push-restic_rclone:${{ matrix.restic_version }}-${{ matrix.rclone_version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/trigger-build.yaml
+++ b/.github/workflows/trigger-build.yaml
@@ -24,26 +24,42 @@ jobs:
 
       - id: get_restic_versions
         name: Get Restic versions
+        shell: bash
         env:
           DOCKER_IMAGE: "restic/restic"
+          GITHUB_REPO: "restic/restic"
           PAGE_SIZE: ${{ vars.UPSTREAM_TAGS_PAGE_SIZE || '6' }}
         run: |
+          # versions=$(
+          #   curl -s "https://hub.docker.com/v2/repositories/${DOCKER_IMAGE}/tags?page_size=${PAGE_SIZE}&page=1" \
+          #   | jq -c '[.results[].name]'
+          # )
+
           versions=$(
-            curl -s "https://hub.docker.com/v2/repositories/${DOCKER_IMAGE}/tags?page_size=${PAGE_SIZE}&page=1" \
-            | jq -c '[.results[].name]'
+            curl -s "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=${PAGE_SIZE}" \
+            | jq -r '["latest"] + [.[] | select(.prerelease == false) | .tag_name | sub("^v"; "")] | .[0:5]'
           )
+
           echo "versions=${versions}" >> $GITHUB_OUTPUT
 
       - id: get_rclone_versions
         name: Get Rclone versions
+        shell: bash
         env:
           DOCKER_IMAGE: "rclone/rclone" 
+          GITHUB_REPO: "rclone/rclone" 
           PAGE_SIZE: ${{ vars.UPSTREAM_TAGS_PAGE_SIZE || '6' }}
         run: |
+          # versions=$(
+          #   curl -s "https://hub.docker.com/v2/repositories/${DOCKER_IMAGE}/tags?page_size=${PAGE_SIZE}&page=1" \
+          #   | jq -c '[.results[].name]'
+          # )
+
           versions=$(
-            curl -s "https://hub.docker.com/v2/repositories/${DOCKER_IMAGE}/tags?page_size=${PAGE_SIZE}&page=1" \
-            | jq -c '[.results[].name]'
+            curl -s "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=${PAGE_SIZE}" \
+            | jq -r '["latest"] + [.[] | select(.prerelease == false) | .tag_name | sub("^v"; "")] | .[0:5]'
           )
+
           echo "versions=${versions}" >> $GITHUB_OUTPUT
 
   build-and-push:

--- a/.github/workflows/trigger-build.yaml
+++ b/.github/workflows/trigger-build.yaml
@@ -24,7 +24,7 @@ jobs:
         env:
           DOCKER_IMAGE: "restic/restic"
           GITHUB_REPO: "restic/restic"
-          PAGE_SIZE: ${{ vars.IMAGE_TAGS_COUNT || '6' }}
+          IMAGE_TAGS_COUNT: ${{ vars.IMAGE_TAGS_COUNT || '6' }}
         run: |
           set -euxo pipefail
 
@@ -50,7 +50,7 @@ jobs:
         env:
           DOCKER_IMAGE: "rclone/rclone" 
           GITHUB_REPO: "rclone/rclone" 
-          PAGE_SIZE: ${{ vars.UPSTREAM_TAGS_PAGE_SIZE || '6' }}
+          IMAGE_TAGS_COUNT: ${{ vars.IMAGE_TAGS_COUNT || '6' }}
         run: |
           set -euxo pipefail
 

--- a/.github/workflows/trigger-build.yaml
+++ b/.github/workflows/trigger-build.yaml
@@ -39,7 +39,7 @@ jobs:
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=50" \
-            | jq -c '["latest"] + [.[] | select(.prerelease == false) | .tag_name | sub("^v"; "")] | .[0:${IMAGE_TAGS_COUNT}]'
+            | jq -c "[\"latest\"] + [.[] | select(.prerelease == false) | .tag_name | sub(\"^v\"; \"\")] | .[0:${IMAGE_TAGS_COUNT}]"
           )
 
           echo "versions=${versions}" >> $GITHUB_OUTPUT
@@ -65,7 +65,7 @@ jobs:
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=50" \
-            | jq -c '["latest"] + [.[] | select(.prerelease == false) | .tag_name | sub("^v"; "")] | .[0:${IMAGE_TAGS_COUNT}]'
+            | jq -c "[\"latest\"] + [.[] | select(.prerelease == false) | .tag_name | sub(\"^v\"; \"\")] | .[0:${IMAGE_TAGS_COUNT}]"
           )
 
           echo "versions=${versions}" >> $GITHUB_OUTPUT

--- a/.github/workflows/trigger-build.yaml
+++ b/.github/workflows/trigger-build.yaml
@@ -5,10 +5,6 @@ on:
     # Every monday at 10:00 UTC
     - cron:  "0 10 * * 1"
   workflow_dispatch:
-  push:
-    branches:
-      - main
-  pull_request:
 
 jobs:
   get_versions:

--- a/.github/workflows/trigger-build.yaml
+++ b/.github/workflows/trigger-build.yaml
@@ -26,6 +26,8 @@ jobs:
           GITHUB_REPO: "restic/restic"
           PAGE_SIZE: ${{ vars.UPSTREAM_TAGS_PAGE_SIZE || '6' }}
         run: |
+          set -euxo pipefail
+
           # versions=$(
           #   curl -s "https://hub.docker.com/v2/repositories/${DOCKER_IMAGE}/tags?page_size=${PAGE_SIZE}&page=1" \
           #   | jq -c '[.results[].name]'
@@ -37,7 +39,7 @@ jobs:
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=${PAGE_SIZE}" \
-            | jq -r '["latest"] + [.[] | select(.prerelease == false) | .tag_name | sub("^v"; "")] | .[0:5]'
+            | jq -c '["latest"] + [.[] | select(.prerelease == false) | .tag_name | sub("^v"; "")] | .[0:5]'
           )
 
           echo "versions=${versions}" >> $GITHUB_OUTPUT
@@ -50,6 +52,8 @@ jobs:
           GITHUB_REPO: "rclone/rclone" 
           PAGE_SIZE: ${{ vars.UPSTREAM_TAGS_PAGE_SIZE || '6' }}
         run: |
+          set -euxo pipefail
+
           # versions=$(
           #   curl -s "https://hub.docker.com/v2/repositories/${DOCKER_IMAGE}/tags?page_size=${PAGE_SIZE}&page=1" \
           #   | jq -c '[.results[].name]'
@@ -61,7 +65,7 @@ jobs:
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=${PAGE_SIZE}" \
-            | jq -r '["latest"] + [.[] | select(.prerelease == false) | .tag_name | sub("^v"; "")] | .[0:5]'
+            | jq -c '["latest"] + [.[] | select(.prerelease == false) | .tag_name | sub("^v"; "")] | .[0:5]'
           )
 
           echo "versions=${versions}" >> $GITHUB_OUTPUT

--- a/.github/workflows/trigger-build.yaml
+++ b/.github/workflows/trigger-build.yaml
@@ -36,7 +36,11 @@ jobs:
           # )
 
           versions=$(
-            curl -s "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=${PAGE_SIZE}" \
+            curl -s \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=${PAGE_SIZE}" \
             | jq -r '["latest"] + [.[] | select(.prerelease == false) | .tag_name | sub("^v"; "")] | .[0:5]'
           )
 
@@ -56,7 +60,11 @@ jobs:
           # )
 
           versions=$(
-            curl -s "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=${PAGE_SIZE}" \
+            curl -s \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=${PAGE_SIZE}" \
             | jq -r '["latest"] + [.[] | select(.prerelease == false) | .tag_name | sub("^v"; "")] | .[0:5]'
           )
 

--- a/.github/workflows/trigger-build.yaml
+++ b/.github/workflows/trigger-build.yaml
@@ -24,12 +24,12 @@ jobs:
         env:
           DOCKER_IMAGE: "restic/restic"
           GITHUB_REPO: "restic/restic"
-          PAGE_SIZE: ${{ vars.UPSTREAM_TAGS_PAGE_SIZE || '6' }}
+          PAGE_SIZE: ${{ vars.IMAGE_TAGS_COUNT || '6' }}
         run: |
           set -euxo pipefail
 
           # versions=$(
-          #   curl -s "https://hub.docker.com/v2/repositories/${DOCKER_IMAGE}/tags?page_size=${PAGE_SIZE}&page=1" \
+          #   curl -s "https://hub.docker.com/v2/repositories/${DOCKER_IMAGE}/tags?page_size=${IMAGE_TAGS_COUNT}&page=1" \
           #   | jq -c '[.results[].name]'
           # )
 
@@ -38,8 +38,8 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=${PAGE_SIZE}" \
-            | jq -c '["latest"] + [.[] | select(.prerelease == false) | .tag_name | sub("^v"; "")] | .[0:5]'
+              "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=50" \
+            | jq -c '["latest"] + [.[] | select(.prerelease == false) | .tag_name | sub("^v"; "")] | .[0:${IMAGE_TAGS_COUNT}]'
           )
 
           echo "versions=${versions}" >> $GITHUB_OUTPUT
@@ -55,7 +55,7 @@ jobs:
           set -euxo pipefail
 
           # versions=$(
-          #   curl -s "https://hub.docker.com/v2/repositories/${DOCKER_IMAGE}/tags?page_size=${PAGE_SIZE}&page=1" \
+          #   curl -s "https://hub.docker.com/v2/repositories/${DOCKER_IMAGE}/tags?page_size=${IMAGE_TAGS_COUNT}&page=1" \
           #   | jq -c '[.results[].name]'
           # )
 
@@ -64,8 +64,8 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=${PAGE_SIZE}" \
-            | jq -c '["latest"] + [.[] | select(.prerelease == false) | .tag_name | sub("^v"; "")] | .[0:5]'
+              "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=50" \
+            | jq -c '["latest"] + [.[] | select(.prerelease == false) | .tag_name | sub("^v"; "")] | .[0:${IMAGE_TAGS_COUNT}]'
           )
 
           echo "versions=${versions}" >> $GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ Images are tagged with a combination of Restic and Rclone tags, in the format:
 
 Example tags: `latest_latest`, `0.16.0_1.64.0`, `latest_1.64.0`, `0.16.0_latest`.
 
-The latest 4 images from both upstreams are maintained. Image building is automatic, via [GitHub actions](https://github.com/tofran/restic-rclone-docker/actions).
+The latest 4 images from both upstreams are maintained.
+Image building is automatic, via [GitHub actions](https://github.com/tofran/restic-rclone-docker/actions).
+
+There is no guarantee the versions are compatible, please check both software releases and
+documentation
 
 ## Architecture support
 
@@ -35,10 +39,10 @@ $ docker pull tofran/restic-rclone:0.15.1_1.61.1
 $ docker pull ghcr.io/tofran/restic-rclone:0.15.1_1.61.1
 
 # Run it:
-$ docker run tofran/restic-rclone:0.15.1_1.61.1 -v
+$ docker run tofran/restic-rclone:0.15.1_1.61.1 version
 #  or
-$ docker run ghcr.io/tofran/restic-rclone:0.15.1_1.61.1 -v
-# > restic 0.15.1 compiled with go1.19.5 on linux/amd64
+$ docker run ghcr.io/tofran/restic-rclone:0.15.1_1.61.1 version
+# > restic 0.18.1 compiled with go1.25.1 on linux/arm64
 ```
 
 `restic` is the default entrypoint.


### PR DESCRIPTION
Instead of using dockerhub tags, it now relies on github releases from both upstreams.

Closes #9 

